### PR TITLE
Initial debian package support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,10 @@ src/x64
 .project
 .idea
 cmake-build-*
+debian/debhelper-build-stamp
+debian/files
+debian/libmirisdr5.debhelper.log
+debian/libmirisdr5.substvars
+debian/libmirisdr5
+debian/.debhelper
+obj-x86_64-linux-gnu/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,7 +46,7 @@ set(CMAKE_BUILD_TYPE ${CMAKE_BUILD_TYPE} CACHE STRING "")
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake/Modules)
 
 # Set the version information here
-set(VERSION_INFO_MAJOR_VERSION 4) # increment major on api compatibility changes
+set(VERSION_INFO_MAJOR_VERSION 5) # increment major on api compatibility changes
 set(VERSION_INFO_MINOR_VERSION 0) # increment minor on feature-level changes
 set(VERSION_INFO_PATCH_VERSION git) # increment patch for bug fixes and docs
 include(Version) # setup version info

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,0 +1,5 @@
+libmirisdr5 (1.1.3-1) UNRELEASED; urgency=medium
+
+  * Initial release.
+
+ -- ericek111 <erik@brocko.eu>  Sat, 22 Jun 2024 09:28:27 +1000

--- a/debian/control
+++ b/debian/control
@@ -1,0 +1,18 @@
+Source: libmirisdr5
+Section: hamradio
+Priority: optional
+Maintainer: ericek111 <erik@brocko.eu>
+Rules-Requires-Root: no
+Build-Depends: debhelper-compat (= 13), cmake, libusb-1.0-0-dev
+Standards-Version: 4.7.0
+Homepage: https://github.com/ericek111/libmirisdr-5
+#Vcs-Browser: https://salsa.debian.org/debian/libmirisdr5
+Vcs-Git: https://github.com/ericek111/libmirisdr-5.git
+
+Package: libmirisdr5
+Architecture: any
+Depends: ${misc:Depends}, ${shlibs:Depends}, libusb-1.0-0
+Conflicts: libmirisdr4
+Multi-Arch: same
+Description: Library for Mirics-based devices
+ Software support for the Mirics based software defined radio devices

--- a/debian/libmirisdr5.install
+++ b/debian/libmirisdr5.install
@@ -1,0 +1,1 @@
+mirisdr.rules /etc/udev/rules.d

--- a/debian/rules
+++ b/debian/rules
@@ -1,0 +1,7 @@
+#!/usr/bin/make -f
+%:
+	dh $@ --buildsystem=cmake
+
+override_dh_auto_configure:
+	dh_auto_configure --buildsystem=cmake -- -DDETACH_KERNEL_DRIVER=ON \
+	-DCMAKE_BUILD_TYPE=RelWithDebInfo


### PR DESCRIPTION
You'll want to check this one out locally and verify that everything is OK.

I did bump the CMAKE version from 4 to 5 to match the library name to avoid any possible conflict with debian's libmirisdr4 package in their repository, this will break things currently linked against the library, which as far as I know is only SoapyMiri.

I'm happy to make any changes to get this merged, the only issue I can think of is this package currently builds as an 'all' package, but in any case you can install it and it does work.

You do need the debhelper-compat and devscripts package installed, but after that creating a debian package is as simple as cd'ing into the folder and typing 'dpkg-buildpackage', similar to how the entire openwebrx+ project is set up.