### PR TITLE
Fix three teardown bugs that wedge or kill the host on a USB stall

### DIFF
--- a/src/async.c
+++ b/src/async.c
@@ -368,6 +368,8 @@ static int mirisdr_async_free (mirisdr_dev_t *p) {
 int mirisdr_read_async (mirisdr_dev_t *p, mirisdr_read_async_cb_t cb, void *ctx, uint32_t num, uint32_t len) {
     size_t i;
     int r, semafor;
+    int transfer_failed = 0;
+    int cancel_tries = 0;
     struct timeval tv = {1, 0};
 
     if (!p) goto failed;
@@ -476,6 +478,19 @@ int mirisdr_read_async (mirisdr_dev_t *p, mirisdr_read_async_cb_t cb, void *ctx,
                 break;
             }
 
+            /* A stalled endpoint may never return its transfers, so do not wait
+             * for them for ever -- that hangs the caller's stream thread. Give
+             * up after a few seconds and leave without freeing: the transfers
+             * are still owned by libusb, and freeing an in-flight transfer
+             * corrupts memory. libusb_close()/libusb_exit() in mirisdr_close()
+             * cleans up from here. */
+            if (++cancel_tries > 5) {
+                fprintf(stderr, "libmirisdr: transfers would not cancel, "
+                                "abandoning them\n");
+                p->async_status = MIRISDR_ASYNC_INACTIVE;
+                return -1;
+            }
+
             /* ukončíme všechny přenosy */
             semafor = 1;
             for (i = 0; i < p->xfer_buf_num; i++) {
@@ -496,7 +511,14 @@ int mirisdr_read_async (mirisdr_dev_t *p, mirisdr_read_async_cb_t cb, void *ctx,
                 break;
             }
         } else if (p->async_status == MIRISDR_ASYNC_FAILED) {
-            goto failed_free;
+            /* Do NOT free the transfers here: on this path some of them are
+             * still submitted, and libusb_free_transfer() on an in-flight
+             * transfer corrupts memory (it crashed the host process every time
+             * a bulk endpoint stalled). Convert the failure into a normal
+             * cancel so the branch above drains every transfer properly, and
+             * remember that it failed so we still return an error. */
+            transfer_failed = 1;
+            p->async_status = MIRISDR_ASYNC_CANCELING;
         }
     }
 
@@ -511,6 +533,11 @@ int mirisdr_read_async (mirisdr_dev_t *p, mirisdr_read_async_cb_t cb, void *ctx,
 #endif
     mirisdr_streaming_stop(p);
     /* je vhodné ukončit i adc, jenže pak by při dalším otevření bylo nutné provést inicializaci */
+
+    if (transfer_failed) {
+        p->async_status = MIRISDR_ASYNC_INACTIVE;
+        return -1;
+    }
 
     return 0;
 

--- a/src/libmirisdr.c
+++ b/src/libmirisdr.c
@@ -271,9 +271,12 @@ int mirisdr_close (mirisdr_dev_t *p) {
                 fprintf(stderr, "Reattaching kernel driver failed!\n");
         }
 #endif
-        if (p->async_status != MIRISDR_ASYNC_FAILED) {
-            libusb_close(p->dh);
-        }
+        /* Always close the handle. Skipping libusb_close() when the async side
+         * had failed leaks the device handle, so the receiver stays claimed and
+         * every later open fails with a stalled endpoint (transfer status 4)
+         * until it is physically replugged -- i.e. exactly the case where
+         * cleaning up matters most. */
+        libusb_close(p->dh);
     }
 
     if (p->ctx) libusb_exit(p->ctx);


### PR DESCRIPTION
Three bugs in the async teardown path, all triggered by a stalled bulk endpoint (`LIBUSB_TRANSFER_STALL`, status 4). Any one of them alone is unpleasant; together they make a stall unrecoverable without physically replugging the receiver.

I hit these while driving an MSi2500 clone from a Windows host that starts and stops the stream repeatedly, but nothing here is Windows-specific.

### 1. `mirisdr_close()` leaks the device handle after a failure

```c
if (p->async_status != MIRISDR_ASYNC_FAILED) {
    libusb_close(p->dh);
}
```

`libusb_close()` is skipped precisely when the async side has failed — the case where cleaning up matters most. The handle leaks, the receiver stays claimed, and every later `mirisdr_open()` fails (`LIBUSB_ERROR_ACCESS`, or transfers that stall immediately) until the device is replugged. Now always closed.

### 2. `libusb_free_transfer()` is called on still-submitted transfers

On the failure path `mirisdr_read_async()` jumps straight to `failed_free:` → `mirisdr_async_free()`, which frees every transfer. But on that path some transfers are still submitted. libusb explicitly forbids freeing an in-flight transfer, and in practice it corrupts the heap: the host process died every time an endpoint stalled.

The normal cancel branch already retires each transfer properly before freeing, so a failure now becomes a normal cancel (`MIRISDR_ASYNC_CANCELING`) and reuses that logic. A `transfer_failed` flag preserves the error so the function still returns `-1`.

### 3. The cancel drain could wait forever

A stalled endpoint may never return its transfers, so the drain loop could spin indefinitely — leaving the caller's stream thread immortal. The process then cannot exit and keeps the device claimed, which is what made the stall look permanent.

The drain is now bounded (a few seconds). On timeout it abandons the transfers rather than freeing them in flight; `libusb_close()`/`libusb_exit()` in `mirisdr_close()` releases them.

### Testing

Verified on real hardware (MSi2500/MSi001 clone, `1df7:2500`, bulk transfers via WinUSB) with a harness that runs 20 back-to-back start/stream/stop cycles and deliberately provokes endpoint stalls.

What these patches fix, and what I actually observed:

- **before:** the first stall killed the host process outright (bug 2), or left an unkillable thread spinning in the cancel loop (bug 3) -- a zombie process that kept the device claimed, so nothing else could open it until it was force-killed.
- **after:** stalls are survived. The process stays alive, keeps running, and exits cleanly; across many repeated sweeps there was no crash, no hang and no leftover process.

Bug 1 is a plain correctness fix -- `libusb_close()` must not be skipped on the error path. Its user-visible effect was entangled with the zombie above, so I am not claiming an independently isolated repro for that one.

**Scope, to set expectations:** these patches are about not crashing or hanging on a stall. They do *not* claim to fix streaming reliability. On this hardware there is a separate, pre-existing problem where the MSi2500's streaming engine does not restart after a session has run -- the next session receives exactly one bulk buffer (whatever was left in the FIFO) and then nothing, until the device is physically replugged. I could not fix that from libmirisdr: `libusb_clear_halt()`, resetting the alternate setting, `mirisdr_streaming_stop()`/`mirisdr_adc_stop()` on close, and `libusb_reset_device()` all failed to prevent or clear it, and on Windows WinUSB has no real port reset, so `libusb_reset_device()` returns success without re-enumerating. That issue is independent of the three bugs fixed here.

Compile-checked with gcc and MSVC; no new warnings against the current tree (the 6 gcc warnings in `mirisdr_open_fd` are pre-existing).
